### PR TITLE
Update CI configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on: [push]
 jobs:
   build:
     name: Mac Build
-    runs-on: macOS-10.14
+    runs-on: macOS-10.15
     steps:
     - uses: actions/checkout@v1
     - name: Fetching premake


### PR DESCRIPTION
Fixes the following warning in github actions

"The macOS virtual environment has been updated to Catalina (v10.15). Please update your workflow and change the line 'runs-on: macOS-10.14'"