### PR TITLE
Users can open directories

### DIFF
--- a/mac/mac-editor/AppDelegate.m
+++ b/mac/mac-editor/AppDelegate.m
@@ -4,6 +4,7 @@
  */
 
 #import "AppDelegate.h"
+#import "ViewController.h"
 
 /*
  * The application delegate is where cocoa notifies us about UI or application
@@ -21,6 +22,23 @@
 }
 
 - (void)applicationWillTerminate:(NSNotification *)aNotification {
+}
+- (IBAction)onFolderOpen:(id)sender {
+    NSWindow* window = [NSApp mainWindow];
+    ViewController* viewController = (ViewController*) [window contentViewController];
+
+    NSOpenPanel* openPanel = [NSOpenPanel openPanel];
+    openPanel.canCreateDirectories = false;
+    openPanel.canChooseFiles = false;
+    openPanel.canChooseDirectories = true;
+    NSModalResponse response = [openPanel runModal];
+    if (response == NSModalResponseOK) {
+        NSArray* urls = [openPanel URLs];
+        NSURL* url = [urls firstObject];
+        if (url != nil) {
+            [viewController addMainDirectory:url];
+        }
+    }
 }
 
 @end

--- a/mac/mac-editor/Base.lproj/Main.storyboard
+++ b/mac/mac-editor/Base.lproj/Main.storyboard
@@ -78,7 +78,11 @@
                                                 </items>
                                             </menu>
                                         </menuItem>
-                                        <menuItem title="Open Directory" keyEquivalent="O" id="t2j-Z9-eDg"/>
+                                        <menuItem title="Open Directory" keyEquivalent="O" id="t2j-Z9-eDg">
+                                            <connections>
+                                                <action selector="onFolderOpen:" target="Voe-Tx-rLC" id="41D-3t-5om"/>
+                                            </connections>
+                                        </menuItem>
                                         <menuItem isSeparatorItem="YES" id="m54-Is-iLE"/>
                                         <menuItem title="Close" keyEquivalent="w" id="DVo-aG-piG">
                                             <connections>

--- a/mac/mac-editor/FileSystemDataSource.h
+++ b/mac/mac-editor/FileSystemDataSource.h
@@ -9,24 +9,45 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
+ * The type of item in the file system hierarchy.
+ *
+ * FS_PROJECTS_LIST: The root of the hierarchy
+ * FS_MAIN_DIRECTORY: A directory that the user chose.
+ * FS_DIRECTORY: A sub-directory of one of the main directories.
+ * FS_FILE: A file.
+ */
+enum FileSystemTypes { FS_DIRECTORY, FS_FILE, FS_PROJECTS_LIST, FS_MAIN_DIRECTORY };
+
+/**
  * One item to display in the file browser. This can represent either
  * a file or a directory.
  */
 @interface FileSystemItem : NSObject {
     NSString *relativePath;
+    NSString *rootPath;
     FileSystemItem *parent;
     NSMutableArray *children;
-    BOOL isValid;
-    BOOL isDir;
+    enum FileSystemTypes type;
 }
 
-+ (FileSystemItem *)rootItem;
+/*
+ * Loads the children of item. Will perform disk access so it
+ * may be slow.
+ * There is no caching; calling loadChildren on the same item
+ * twice will result in the disk being accessed twice.
+ * The caller is in charge of caching as it sees fit.
+ */
 + (NSMutableArray *)loadChildren:(FileSystemItem *)item;
+- (id)initWithProjectsList;
+- (id)initWithMainDirectory:(NSString *)path;
+- (id)initWithPathAndParent:(NSString *)path parent:(FileSystemItem *)parentItem;
 - (NSInteger)numberOfChildren;                   // Returns -1 for leaf nodes
 - (FileSystemItem *)childAtIndex:(NSUInteger)n;  // Invalid to call on leaf nodes
 - (NSString *)fullPath;
 - (NSString *)relativePath;
 - (BOOL)isValidDir;
+- (enum FileSystemTypes)getType;
+- (void)addChild:(FileSystemItem *)item;
 
 @end
 
@@ -37,6 +58,22 @@ NS_ASSUME_NONNULL_BEGIN
  * cocoa does not know how to display.
  */
 @interface FileSystemDataSource : NSObject<NSOutlineViewDataSource, NSOutlineViewDelegate>
+
+/**
+ * The projects list. You can add items here  and they will be displayed in the directories list.
+ */
+@property FileSystemItem *projectTree;
+
+/**
+ * Initialize the data source.
+ */
+-(instancetype)init;
+
+/**
+ * Add a project to the files list. Once added, the caller needs to reload the
+ * data in the outline view in order for the new directory to be shown.
+ */
+- (void)addProject:(FileSystemItem *)item;
 
 @end
 

--- a/mac/mac-editor/ViewController.h
+++ b/mac/mac-editor/ViewController.h
@@ -11,4 +11,9 @@
  */
 @interface ViewController : NSViewController
 
+/**
+ * Adds a directory to the files outline view.
+ */
+- (void)addMainDirectory:(NSURL*)url;
+
 @end


### PR DESCRIPTION
The user can now control which directories are shown in the left
side bar.

User can add more than 1 directory.

Demo
===

<img width="1159" alt="Screen Shot 2020-10-31 at 6 37 50 PM" src="https://user-images.githubusercontent.com/1117179/97793371-4621ad80-1ba8-11eb-9ffb-53b014bb07d9.png">

Dev
====
A very important side effect: I removed loading files
from a background thread. I could not get background loading
to work in conjunction with adding multiple directories.